### PR TITLE
correct use of AtomicInteger

### DIFF
--- a/src/main/java/io/vertx/examples/loadbalancer/routing/impl/RoundRobinRouter.java
+++ b/src/main/java/io/vertx/examples/loadbalancer/routing/impl/RoundRobinRouter.java
@@ -16,8 +16,6 @@ public class RoundRobinRouter extends Router {
 
 	@Override
 	protected ProxyHandler chooseProxyFor(HttpServerRequest request) {
-		int i = counter.getAndIncrement();
-		counter.compareAndSet(slaves.size(), 0);
-		return slaves.get(i);
+		return slaves.get(counter.getAndIncrement() % slaves.size());
 	}
 }


### PR DESCRIPTION
I was looking for a way to do a round robin load balancer with vertx, and I found out your repo.

In your code, getAndIncrement and compareAndSet are 2 different atomicals operations. Consequently, in some cases, the counter may never be reset to 0, and produce an IndexOutOfBoundsException when getting the slave in the list.
